### PR TITLE
Updating AirQuality scales

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function ClearGrassAirMonitor(log, config) {
     this.co2 = null;
     this.aqi = Characteristic.AirQuality.UNKNOWN;
 
-    // Using US PM2.5 scale
+    // Using US PM2.5 scale from Clear Grass Air Monitor
     this.pm25Levels = [
         [250, Characteristic.AirQuality.SEVERELY_POLLUTED],
         [150, Characteristic.AirQuality.HEAVILY_POLLUTED],
@@ -43,12 +43,12 @@ function ClearGrassAirMonitor(log, config) {
         [12, Characteristic.AirQuality.GOOD],
         [0, Characteristic.AirQuality.EXCELLENT],
     ];
-    // Using real tVOC pollution scale
+    // Using tVOC pollution scale from Clear Frass Air Monitor
     this.tvocLevels = [
-        [9, Characteristic.AirQuality.VERY_HIGH],
-        [3, Characteristic.AirQuality.HIGH],
-        [1, Characteristic.AirQuality.SLIGHTLY_HIGH],
-        [0.3, Characteristic.AirQuality.GOOD],
+        [2000, Characteristic.AirQuality.UNHEALTHY],
+        [660, Characteristic.AirQuality.HIGH],
+        [220, Characteristic.AirQuality.MODERATE],
+        [65, Characteristic.AirQuality.GOOD],
         [0, Characteristic.AirQuality.EXCELLENT],
     ];
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function ClearGrassAirMonitor(log, config) {
         [3, Characteristic.AirQuality.HIGH],
         [1, Characteristic.AirQuality.SLIGHTLY_HIGH],
         [0.3, Characteristic.AirQuality.GOOD],
-        [0, Characteristic.AirQuality.EXCELLENT]
+        [0, Characteristic.AirQuality.EXCELLENT],
     ];
 
     this.services = [];

--- a/index.js
+++ b/index.js
@@ -36,10 +36,10 @@ function ClearGrassAirMonitor(log, config) {
 
     // Using US PM2.5 scale from Clear Grass Air Monitor
     this.pm25Levels = [
-        [250, Characteristic.AirQuality.SEVERELY_POLLUTED],
-        [150, Characteristic.AirQuality.HEAVILY_POLLUTED],
-        [55, Characteristic.AirQuality.MODERATELY_POLLUTED],
-        [35, Characteristic.AirQuality.SLIGHTLY_POLLUTED],
+        [250, Characteristic.AirQuality.UNHEALTHY],
+        [150, Characteristic.AirQuality.HIGH],
+        [55, Characteristic.AirQuality.MODERATE],
+        [35, Characteristic.AirQuality.FAIR],
         [12, Characteristic.AirQuality.GOOD],
         [0, Characteristic.AirQuality.EXCELLENT],
     ];

--- a/index.js
+++ b/index.js
@@ -34,19 +34,21 @@ function ClearGrassAirMonitor(log, config) {
     this.co2 = null;
     this.aqi = Characteristic.AirQuality.UNKNOWN;
 
+    // Using US PM2.5 scale
     this.pm25Levels = [
-        [150, Characteristic.AirQuality.POOR],
-        [115, Characteristic.AirQuality.INFERIOR],
-        [75, Characteristic.AirQuality.FAIR],
-        [35, Characteristic.AirQuality.GOOD],
+        [250, Characteristic.AirQuality.SEVERELY_POLLUTED],
+        [150, Characteristic.AirQuality.HEAVILY_POLLUTED],
+        [55, Characteristic.AirQuality.MODERATELY_POLLUTED],
+        [35, Characteristic.AirQuality.SLIGHTLY_POLLUTED],
+        [12, Characteristic.AirQuality.GOOD],
         [0, Characteristic.AirQuality.EXCELLENT],
     ];
+    // Using real tVOC pollution scale
     this.tvocLevels = [
-        [2000, Characteristic.AirQuality.POOR],
-        [660, Characteristic.AirQuality.INFERIOR],
-        [220, Characteristic.AirQuality.FAIR],
-        [65, Characteristic.AirQuality.GOOD],
-        [0, Characteristic.AirQuality.EXCELLENT],
+        [9, Characteristic.AirQuality.VERY_HIGH],
+        [3, Characteristic.AirQuality.HIGH],
+        [1, Characteristic.AirQuality.SLIGHTLY_HIGH],
+        [0.3, Characteristic.AirQuality.GOOD],
     ];
 
     this.services = [];

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ function ClearGrassAirMonitor(log, config) {
         [3, Characteristic.AirQuality.HIGH],
         [1, Characteristic.AirQuality.SLIGHTLY_HIGH],
         [0.3, Characteristic.AirQuality.GOOD],
+        [0, Characteristic.AirQuality.EXCELLENT]
     ];
 
     this.services = [];


### PR DESCRIPTION
Description:
Updating AirQuality scales to be inline with AirQuality.gov aka US instead of CN standard, also updated scale labels per AirQuality.gov as current pollution levels are not very descriptive